### PR TITLE
Update host association method for network changes

### DIFF
--- a/app/models/foreman_one/one.rb
+++ b/app/models/foreman_one/one.rb
@@ -115,13 +115,8 @@ module ForemanOne
       false
     end
 
-#    def associated_host(vm)
-#      Host.my_hosts.where(:ip => [vm.public_ip_address, vm.private_ip_address]).first
-#    end
-
     def associated_host(vm)
-      #Host.my_hosts.where(:mac => [vm.vm_mac_address]).first
-      Host.authorized(:view_hosts, Host).where(:mac => vm.vm_mac_address).first
+      associate_by("mac", vm.vm_mac_address)
     end
 
     def new_vminterface attr={}

--- a/lib/foreman_one/engine.rb
+++ b/lib/foreman_one/engine.rb
@@ -16,7 +16,7 @@ module ForemanOne
 
     initializer 'foreman_one.register_plugin', :after=> :finisher_hook do |app|
       Foreman::Plugin.register :foreman_one do
-        requires_foreman '> 1.4'
+        requires_foreman '>= 1.8'
         # Register OpenNebula compute resource in foreman
         compute_resource ForemanOne::One
       end


### PR DESCRIPTION
Since Foreman 1.8, MACs are stored in the nics table instead of hosts
and a helper is provided to CRs to query it.